### PR TITLE
fix output bug when using int8 kv cache

### DIFF
--- a/examples/frontend_language/quick_start/local_example_chat.py
+++ b/examples/frontend_language/quick_start/local_example_chat.py
@@ -57,19 +57,11 @@ def batch():
 
 
 if __name__ == "__main__":
-    runtime = sgl.Runtime(model_path="meta-llama/Llama-2-7b-chat-hf")
+    runtime = sgl.Runtime(model_path="/root/autodl-tmp/model/Qwen2.5-7B-Instruct", kv_cache_dtype="int8", attention_backend="triton")
     sgl.set_default_backend(runtime)
 
     # Run a single request
     print("\n========== single ==========\n")
     single()
-
-    # Stream output
-    print("\n========== stream ==========\n")
-    stream()
-
-    # Run a batch of requests
-    print("\n========== batch ==========\n")
-    batch()
 
     runtime.shutdown()

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -247,7 +247,7 @@ def _decode_att_m_fwd(
 
     # assert kv dtype
     print(k_buffer.dtype)
-    USE_INT8_KV = k_buffer[0].dtype == torch.int8
+    USE_INT8_KV = k_buffer[0].dtype == torch.uint8
 
     batch, head_num = B_req_idx.shape[0], q.shape[1]
 
@@ -568,7 +568,7 @@ def _decode_grouped_att_m_fwd(
     Lv = v_buffer.shape[-1]
 
     # assert kv dtype
-    USE_INT8_KV = k_buffer[0].dtype == torch.int8
+    USE_INT8_KV = k_buffer[0].dtype == torch.uint8
 
     if Lk == 576:
         BLOCK_DMODEL = 512

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -346,7 +346,7 @@ def extend_attention_fwd(
     """
 
     # assert kv dtype
-    USE_INT8_KV = k_buffer[0].dtype == torch.int8
+    USE_INT8_KV = k_buffer[0].dtype == torch.uint8
 
     Lq, Lk, Lv = (
         q_extend.shape[-1],

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -106,6 +106,7 @@ class BaseTokenToKVPool:
     ):
         self.size = size
         self.kv_cache_dtype = kv_cache_dtype
+        print(kv_cache_dtype)
         if kv_cache_dtype == torch.float8_e5m2 or kv_cache_dtype == torch.int8:
             # NOTE: Store as torch.uint8 because Tensor index_put is not implemented for torch.float8_e5m2
             self.store_dtype = torch.uint8
@@ -203,6 +204,7 @@ class MHATokenToKVPool(BaseTokenToKVPool):
     def _create_buffers(self):
         # [size, head_num, head_dim] for each layer
         # The padded slot 0 is used for writing dummy outputs from padded tokens.
+        print(self.store_dtype)
         self.k_buffer = [
             torch.empty(
                 (self.size + 1, self.head_num, self.head_dim),
@@ -241,12 +243,12 @@ class MHATokenToKVPool(BaseTokenToKVPool):
         del self.v_buffer
 
     def get_key_buffer(self, layer_id: int):
-        if self.store_dtype != self.kv_cache_dtype:
+        if self.kv_cache_dtype == torch.float8_e5m2 and self.store_dtype != self.kv_cache_dtype:
             return self.k_buffer[layer_id].view(self.kv_cache_dtype)
         return self.k_buffer[layer_id]
 
     def get_value_buffer(self, layer_id: int):
-        if self.store_dtype != self.kv_cache_dtype:
+        if self.kv_cache_dtype == torch.float8_e5m2 and self.store_dtype != self.kv_cache_dtype:
             return self.v_buffer[layer_id].view(self.kv_cache_dtype)
         return self.v_buffer[layer_id]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.


fp8 use return self.v_buffer[layer_id].view(self.kv_cache_dtype) to view，but int8 need uint8 for kv cache